### PR TITLE
Add a second parameter to the termination callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # IntelliJ project files
 .idea
 
+# Visual Studio project files
+.vscode
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# server-terminate
 Allow terminating an HTTP server in an orderly fashion:
 * Immediately closes keep-alive connections that are not being used by any HTTP request. 
 * Waits for running HTTP requests to finish before closing their connections.
@@ -23,7 +24,7 @@ enableTerminate(server).listen(PORT));
 
 
 // When you want to stop your server...
-server.terminate(function(err,terminatedByTimeout) {
+server.terminate(function(err, terminatedByTimeout) {
   // You get here when all connections have been closed
 });
 ```
@@ -33,7 +34,8 @@ It is measured in milliseconds and defaults to 30000.
 ```javascript
 enableTerminate(server, {timeout: 10000}).listen(PORT));
 ```
-If the server terminates by timeout the second paramater of the callback will be `true`.
+
+If the server terminates by timeout the second parameter of the callback will be `true`.
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# server-terminate
 Allow terminating an HTTP server in an orderly fashion:
 * Immediately closes keep-alive connections that are not being used by any HTTP request. 
 * Waits for running HTTP requests to finish before closing their connections.
@@ -24,7 +23,7 @@ enableTerminate(server).listen(PORT));
 
 
 // When you want to stop your server...
-server.terminate(function() {
+server.terminate(function(err,terminatedByTimeout) {
   // You get here when all connections have been closed
 });
 ```
@@ -34,6 +33,7 @@ It is measured in milliseconds and defaults to 30000.
 ```javascript
 enableTerminate(server, {timeout: 10000}).listen(PORT));
 ```
+If the server terminates by timeout the second paramater of the callback will be `true`.
 
 ## License
 MIT

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = function enableTerminate(server, opts) {
 
   var connections = {};
   var terminating = false;
+  var terminatedByTimeout = false;
 
   server.on('connection', function onConnection(conn) {
     // Save each new connection along with the number of running requests over that connection
@@ -77,7 +78,7 @@ module.exports = function enableTerminate(server, opts) {
         return cb(err);
       }
       clearTimeout(timeoutId);
-      cb();
+      cb(null, terminatedByTimeout);
     });
 
     // Destroy open connections that have no running requests
@@ -91,6 +92,7 @@ module.exports = function enableTerminate(server, opts) {
     // If the timeout expires, force the destruction of all the pending connections,
     // even if they have some running requests yet
     timeoutId = setTimeout(function() {
+      terminatedByTimeout = true;
       for (var id in connections) {
         connections[id].conn.destroy();
         delete connections[id];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-terminate",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Allow terminating a server in an orderly fashion",
   "license": "MIT",
   "author": "Jose Antonio Rodríguez <joseantonio.rodriguezfernandez@telefonica.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-terminate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Allow terminating a server in an orderly fashion",
   "license": "MIT",
   "author": "Jose Antonio Rodríguez <joseantonio.rodriguezfernandez@telefonica.com>",

--- a/test.js
+++ b/test.js
@@ -219,7 +219,8 @@ feature('Terminate an HTTP server', function() {
     var TIMEOUT = 1000,
         server,
         duration,
-        error;
+        error,
+        terminatedByTimeout;
 
     given('that I have an HTTP server with the "terminate" function configured with a timeout', function(done) {
       server = enableTerminate(http.createServer(function onRequest(req, res) {
@@ -247,8 +248,9 @@ feature('Terminate an HTTP server', function() {
     });
     when('I terminate the server', function(done) {
       var start = process.hrtime();
-      server.terminate(function() {
+      server.terminate(function(err, terminatedByTimeout_) {
         duration = process.hrtime(start);
+        terminatedByTimeout = terminatedByTimeout_;
         done();
       });
     });
@@ -260,6 +262,9 @@ feature('Terminate an HTTP server', function() {
     then('It waits for the running request to finish or the timeout expires', function() {
       expect(hr2ms(duration)).to.be.closeTo(TIMEOUT, 50);
       expect(error).to.have.property('code', 'ECONNRESET');
+    });
+    and('and terminatedByTimeout parameter is true', function() {
+      expect(terminatedByTimeout).to.be.true;
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -61,7 +61,8 @@ feature('Terminate an HTTP server', function() {
 
   scenario('No requests have been performed yet against the server', function() {
     var server,
-        duration;
+        duration,
+        terminatedByTimeout;
 
     given('that I have an HTTP server with the "terminate" function', function(done) {
       server = enableTerminate(http.createServer(function onRequest(req, res) {
@@ -74,13 +75,17 @@ feature('Terminate an HTTP server', function() {
     });
     when('I terminate the server', function(done) {
       var start = process.hrtime();
-      server.terminate(function() {
+      server.terminate(function(err, terminatedByTimeout_) {
         duration = process.hrtime(start);
+        terminatedByTimeout = terminatedByTimeout_;
         done();
       });
     });
     then('It is immediately closed', function() {
       expect(hr2ms(duration)).to.be.below(10);
+    });
+    and('and the terminatedByTimeout parameter is false', function() {
+      expect(terminatedByTimeout).to.be.false;
     });
   });
 
@@ -91,7 +96,8 @@ feature('Terminate an HTTP server', function() {
   ];
   scenario('Some requests have been completed and their connections have been closed', dataset, function(variant) {
     var server,
-        duration;
+        duration,
+        terminatedByTimeout;
 
     given('that I have an HTTP server with the "terminate" function', function(done) {
       server = enableTerminate(http.createServer(function onRequest(req, res) {
@@ -125,19 +131,24 @@ feature('Terminate an HTTP server', function() {
     });
     when('I terminate the server', function(done) {
       var start = process.hrtime();
-      server.terminate(function() {
+      server.terminate(function(err, terminatedByTimeout_) {
         duration = process.hrtime(start);
+        terminatedByTimeout = terminatedByTimeout_;
         done();
       });
     });
     then('It is immediately closed', function() {
       expect(hr2ms(duration)).to.be.below(10);
     });
+    and('and the terminatedByTimeout parameter is false', function() {
+      expect(terminatedByTimeout).to.be.false;
+    });
   });
 
   scenario('Some requests have been completed but their connections are still open', function() {
     var server,
-        duration;
+        duration,
+        terminatedByTimeout;
 
     given('that I have an HTTP server with the "terminate" function', function(done) {
       server = enableTerminate(http.createServer(function onRequest(req, res) {
@@ -163,20 +174,25 @@ feature('Terminate an HTTP server', function() {
     });
     when('I terminate the server', function(done) {
       var start = process.hrtime();
-      server.terminate(function() {
+      server.terminate(function(err, terminatedByTimeout_) {
         duration = process.hrtime(start);
+        terminatedByTimeout = terminatedByTimeout_;
         done();
       });
     });
     then('It is immediately closed', function() {
       expect(hr2ms(duration)).to.be.below(10);
     });
+    and('and the terminatedByTimeout parameter is false', function() {
+      expect(terminatedByTimeout).to.be.false;
+    });
   });
 
   scenario('There are running requests', function() {
     var DELAY = 2000,
         server,
-        duration;
+        duration,
+        terminatedByTimeout;
 
     given('that I have an HTTP server with the "terminate" function', function(done) {
       server = enableTerminate(http.createServer(function onRequest(req, res) {
@@ -201,13 +217,17 @@ feature('Terminate an HTTP server', function() {
     });
     when('I terminate the server', function(done) {
       var start = process.hrtime();
-      server.terminate(function() {
+      server.terminate(function(err, terminatedByTimeout_) {
         duration = process.hrtime(start);
+        terminatedByTimeout = terminatedByTimeout_;
         done();
       });
     });
     then('It waits for the running requests to finish', function() {
       expect(hr2ms(duration)).to.be.closeTo(DELAY - (DELAY / 2), 50);
+    });
+    and('and the terminatedByTimeout parameter is false', function() {
+      expect(terminatedByTimeout).to.be.false;
     });
   });
 
@@ -263,7 +283,7 @@ feature('Terminate an HTTP server', function() {
       expect(hr2ms(duration)).to.be.closeTo(TIMEOUT, 50);
       expect(error).to.have.property('code', 'ECONNRESET');
     });
-    and('and terminatedByTimeout parameter is true', function() {
+    and('and the terminatedByTimeout parameter is true', function() {
       expect(terminatedByTimeout).to.be.true;
     });
   });


### PR DESCRIPTION
Add a second parameter to the terminate callback to indicate if the server terminates by timeout
